### PR TITLE
add some ODF mime types (text, spreadsheet, presentation, drawing)

### DIFF
--- a/sql/data/mime_type.sql
+++ b/sql/data/mime_type.sql
@@ -10,6 +10,10 @@ INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/rt
 INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/vnd.ms-powerpoint', 'ppt', false);
 INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/vnd.sun.xml.impress', 'sxi', false);
 INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/vnd.sun.xml.writer', 'sxw', false);
+INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/vnd.oasis.opendocument.text', 'odt', false);
+INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/vnd.oasis.opendocument.spreadsheet', 'ods', false);
+INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/vnd.oasis.opendocument.presentation', 'odp', false);
+INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/vnd.oasis.opendocument.graphics', 'odg', false);
 INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/x-bittorrent', 'torrent', false);
 INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/x-bzip2', 'bz2', false);
 INSERT INTO mime_type (mime_type, file_extension, image) VALUES ('application/x-gzip', 'gz', false);

--- a/sql/data/mime_type_localized.sql
+++ b/sql/data/mime_type_localized.sql
@@ -18,6 +18,14 @@ INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('applicati
 INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.sun.xml.impress', 'en', 'OpenOffice Presentation');
 INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.sun.xml.writer', 'de', 'OpenOffice Dokument');
 INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.sun.xml.writer', 'en', 'OpenOffice document');
+INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.oasis.opendocument.text', 'de', 'ODF Textdokument');
+INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.oasis.opendocument.text', 'en', 'ODF Text Document');
+INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.oasis.opendocument.spreadsheet', 'de', 'ODF Tabellendokument');
+INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.oasis.opendocument.spreadsheet', 'en', 'ODF Spreadsheet');
+INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.oasis.opendocument.presentation', 'de', 'ODF Präsentation');
+INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.oasis.opendocument.presentation', 'en', 'ODF Presentation');
+INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.oasis.opendocument.graphics', 'de', 'ODF Zeichnung');
+INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/vnd.oasis.opendocument.graphics', 'en', 'ODF Drawing');
 INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/x-bittorrent', 'de', 'Bittorrent');
 INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/x-bittorrent', 'en', 'Bittorrent');
 INSERT INTO mime_type_localized (mime_type, translated, name) VALUES ('application/x-bzip2', 'de', 'BZ2-komprimierte Datei');


### PR DESCRIPTION
While uploading my FOSDEM talk slides, noticed that pentabarf detects proprietary MS Office file types but not standard ODF ones; this (untested) patch should fix that.
