### PR TITLE
Update links to modern https default

### DIFF
--- a/rails/app/views/conference/_conference_general.rxml
+++ b/rails/app/views/conference/_conference_general.rxml
@@ -89,7 +89,7 @@ xml.div(:id=>'content-general') do
           xml.td do
             xml.input({:type=>:hidden,:id=>'conference_link[row_id][current_transaction_id]',:name=>'conference_link[row_id][current_transaction_id]'})
             xml.input({:type=>:hidden,:id=>'conference_link[row_id][conference_link_id]',:name=>'conference_link[row_id][conference_link_id]'})
-            xml.input({:type=>:text,:id=>'conference_link[row_id][url]',:name=>'conference_link[row_id][url]',:value=>"http://",:onchange=>"$('conference_link[row_id][link]').setAttribute( 'href', $F(this));"})
+            xml.input({:type=>:text,:id=>'conference_link[row_id][url]',:name=>'conference_link[row_id][url]',:value=>"https://",:onchange=>"$('conference_link[row_id][link]').setAttribute( 'href', $F(this));"})
           end
           xml.td do xml.input({:type=>:text,:id=>'conference_link[row_id][title]',:name=>'conference_link[row_id][title]'}) end
           xml.td do xml.input({:type=>:checkbox,:name=>'conference_link[row_id][remove]',:id=>'conference_link[row_id][remove]'}) end

--- a/rails/app/views/event/_event_links.rxml
+++ b/rails/app/views/event/_event_links.rxml
@@ -20,7 +20,7 @@ xml.div(:id=>'content-links') do
           xml.td do
             xml.input({:type=>:hidden,:id=>'event_link[row_id][current_transaction_id]',:name=>'event_link[row_id][current_transaction_id]'})
             xml.input({:type=>:hidden,:id=>'event_link[row_id][event_link_id]',:name=>'event_link[row_id][event_link_id]'})
-            xml.input({:type=>:text,:id=>'event_link[row_id][url]',:name=>'event_link[row_id][url]',:value=>"http://",:onchange=>"$('event_link[row_id][link]').setAttribute( 'href', $F(this));"})
+            xml.input({:type=>:text,:id=>'event_link[row_id][url]',:name=>'event_link[row_id][url]',:value=>"https://",:onchange=>"$('event_link[row_id][link]').setAttribute( 'href', $F(this));"})
           end
           xml.td do xml.input({:type=>:text,:id=>'event_link[row_id][title]',:name=>'event_link[row_id][title]'}) end
           xml.td do xml.input({:type=>:checkbox,:name=>'event_link[row_id][remove]',:id=>'event_link[row_id][remove]'}) end

--- a/rails/app/views/person/_person_links.rxml
+++ b/rails/app/views/person/_person_links.rxml
@@ -20,7 +20,7 @@ xml.div(:id=>'content-links') do
           xml.td do
             xml.input({:type=>:hidden,:id=>'conference_person_link[row_id][current_transaction_id]',:name=>'conference_person_link[row_id][current_transaction_id]'})
             xml.input({:type=>:hidden,:id=>'conference_person_link[row_id][conference_person_link_id]',:name=>'conference_person_link[row_id][conference_person_link_id]'})
-            xml.input({:type=>:text,:id=>'conference_person_link[row_id][url]',:name=>'conference_person_link[row_id][url]',:value=>'http://',:onchange=>"$('conference_person_link[row_id][link]').setAttribute( 'href', $F(this));"})
+            xml.input({:type=>:text,:id=>'conference_person_link[row_id][url]',:name=>'conference_person_link[row_id][url]',:value=>'https://',:onchange=>"$('conference_person_link[row_id][link]').setAttribute( 'href', $F(this));"})
           end
           xml.td do xml.input({:type=>:text,:id=>'conference_person_link[row_id][title]',:name=>'conference_person_link[row_id][title]'}) end
           xml.td do xml.input({:type=>:checkbox,:name=>'conference_person_link[row_id][remove]',:id=>'conference_person_link[row_id][remove]'}) end

--- a/rails/app/views/submission/_event_links.rxml
+++ b/rails/app/views/submission/_event_links.rxml
@@ -20,7 +20,7 @@ xml.div(:id=>'content-links') do
           xml.td do
             xml.input({:type=>:hidden,:id=>'event_link[row_id][current_transaction_id]',:name=>'event_link[row_id][current_transaction_id]'})
             xml.input({:type=>:hidden,:id=>'event_link[row_id][event_link_id]',:name=>'event_link[row_id][event_link_id]'})
-            xml.input({:type=>:text,:id=>'event_link[row_id][url]',:name=>'event_link[row_id][url]',:value=>"http://",:onchange=>"$('event_link[row_id][link]').setAttribute( 'href', $F(this));"})
+            xml.input({:type=>:text,:id=>'event_link[row_id][url]',:name=>'event_link[row_id][url]',:value=>"https://",:onchange=>"$('event_link[row_id][link]').setAttribute( 'href', $F(this));"})
           end
           xml.td do xml.input({:type=>:text,:id=>'event_link[row_id][title]',:name=>'event_link[row_id][title]'}) end
           xml.td do xml.input({:type=>:checkbox,:name=>'event_link[row_id][remove]',:id=>'event_link[row_id][remove]'}) end

--- a/rails/app/views/submission/_person_links.rxml
+++ b/rails/app/views/submission/_person_links.rxml
@@ -20,7 +20,7 @@ xml.div(:id=>'content-links') do
           xml.td do
             xml.input({:type=>:hidden,:id=>'conference_person_link[row_id][current_transaction_id]',:name=>'conference_person_link[row_id][current_transaction_id]'})
             xml.input({:type=>:hidden,:id=>'conference_person_link[row_id][conference_person_link_id]',:name=>'conference_person_link[row_id][conference_person_link_id]'})
-            xml.input({:type=>:text,:id=>'conference_person_link[row_id][url]',:name=>'conference_person_link[row_id][url]',:value=>'http://',:onchange=>"$('conference_person_link[row_id][link]').setAttribute( 'href', $F(this));"})
+            xml.input({:type=>:text,:id=>'conference_person_link[row_id][url]',:name=>'conference_person_link[row_id][url]',:value=>'https://',:onchange=>"$('conference_person_link[row_id][link]').setAttribute( 'href', $F(this));"})
           end
           xml.td do xml.input({:type=>:text,:id=>'conference_person_link[row_id][title]',:name=>'conference_person_link[row_id][title]'}) end
           xml.td do xml.input({:type=>:checkbox,:name=>'conference_person_link[row_id][remove]',:id=>'conference_person_link[row_id][remove]'}) end


### PR DESCRIPTION
We all add links, but most of them don't start with http:// anymore.

NOTE: I don't know if this is maintained somewhere else, but if so, please either cherry-pick this patch over or point me to the new version. These old values are still present in FOSDEM 2020.